### PR TITLE
Null check for child mapping

### DIFF
--- a/tools/lscrtoscript/js/ast.js
+++ b/tools/lscrtoscript/js/ast.js
@@ -182,7 +182,7 @@ window.AST = (function () {
 		toString() {
 			const indent = "\n  ";
 			if (this.children.length > 0){
-				return indent + this.children.map(child => child.toString().split("\n").join(indent)).join(indent);
+				return indent + this.children.map(child => child === null ? "" : child.toString().split("\n").join(indent)).join(indent);
 			}
 			return "";
 		}


### PR DESCRIPTION
Line 185 throws uncaught TypeError "Cannot read property 'toString' of null", if child is null, duh. So changed child to empty string if it's null. (With this if some childs are null, rest of the stuff will be show still; otherwise it won't show anything on right.htm.)
Here's screenshot about that error:
![Gyazo pic](https://i.gyazo.com/6cb02ce4a8f03bbd8fe58b781f9911c9.png)