### PR TITLE
Read 4 byte integers and floats and handle more unknown bytecode

### DIFF
--- a/tools/lscrtoscript/js/ast.js
+++ b/tools/lscrtoscript/js/ast.js
@@ -73,6 +73,17 @@ window.AST = (function () {
 	}
 	AST.ERROR = ERROR;
 
+	class SYS extends Node {
+		constructor(value) {
+			super();
+			this.value = value;
+		}
+		toString() {
+			return this.value;
+		}
+	}
+	AST.SYS = SYS;
+
 	/* Comment */
 
 	class Comment extends Node {

--- a/tools/lscrtoscript/js/projectorrays.js
+++ b/tools/lscrtoscript/js/projectorrays.js
@@ -925,10 +925,6 @@ Bytecode.prototype.getOpcode = function(val) {
 		0x2f: "pushint32",
 		0x31: "pushfloat32"
 	};
-	
-	if (val == 239) {
-		alert(val < 0x40 ? oneByteCodes[val] : val % 0x40);
-	}
 
 	var opcode = val < 0x40 ? oneByteCodes[val] : multiByteCodes[val % 0x40];
 	return opcode || "unk_" + val.toString(16);


### PR DESCRIPTION
Just an attempt to handle more bytecode and remove some of the "UNK_xx" found when viewing in lscrtoscript.

For example, when uploading hh_photo.cst

```
on countCS(me, tImg)
  tL = [3, 2, 73, 28, 83, 21, 43, 90, 92, 91, 37, 4, 3, 84, 12, 102, 103, 108, 97, 43, 44, 89, 109, 65, 61, -4, 76]
  tA = 0
  tW = tImg.width
  tH = tImg.height
  i = 1
  repeat while i <= 100
    tA = ERROR mod ERROR mod tA + tImg.getPixel(i mod tW, i * i mod tH).paletteIndex * tL.getAt(i mod tL.count + 1).undefined
    i = 1 + i
  end repeat
  return(tA)
  exit
end
```

Now turns into

```
on countCS(me,tImg)
  tL = [3, 2, 73, 28, 83, 21, 43, 90, 92, 91, 37, 4, 3, 84, 12, 102, 103, 108, 97, 43, 44, 89, 109, 65, 61, -4, 76]
  tA = 0
  tW = tImg.width
  tH = tImg.height
  i = 1
  repeat while i <= 100
    tA = tA + tImg.getPixel(i mod tW, i * i mod tH).paletteIndex * tL.getAt(i mod tL.count + 1) mod 85000
    i = 1 + i
  end repeat
  return(tA)
  exit
end
```